### PR TITLE
Add 'lowercase-ify' and 'uppercase-ify' functionality

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,11 @@ function App() {
     setTextOutput(textInput.toLowerCase())
   };
 
+  const handleSubmitUpper = event => {
+    event.preventDefault();
+    setTextOutput(textInput.toUpperCase())
+  }
+
   return (
     <div className="App">
       <header>
@@ -24,6 +29,7 @@ function App() {
           <textarea onChange={handleChange} value={textInput}/>
         </label>
         <input type="submit" value="Lowercase-ify!" onClick={handleSubmitLower}/>
+        <input type="submit" value="Uppercase-ify!" onClick={handleSubmitUpper}/>
       </form>
       <div id="result">
         {textOutput}

--- a/src/App.js
+++ b/src/App.js
@@ -9,9 +9,9 @@ function App() {
     setTextInput(event.target.value);
   };
 
-  const handleSubmit = event => {
+  const handleSubmitLower = event => {
     event.preventDefault();
-    setTextOutput('Your formatted text will go here!')
+    setTextOutput(textInput.toLowerCase())
   };
 
   return (
@@ -19,11 +19,11 @@ function App() {
       <header>
         <h1>Career Lab | Take-Home Assignment</h1>
       </header>
-      <form onSubmit={handleSubmit}>
+      <form>
         <label>
           <textarea onChange={handleChange} value={textInput}/>
         </label>
-        <input type="submit" value="Submit"/>
+        <input type="submit" value="Lowercase-ify!" onClick={handleSubmitLower}/>
       </form>
       <div id="result">
         {textOutput}


### PR DESCRIPTION
## Description

Add 'lowercase-ify' and 'uppercase-ify' functionality to app

## Related Issue

#1 

## Acceptance Criteria

- User should be able to click a button to convert their text input into an output that is all uppercase
- User should be able to click a button to convert their text input into an output that is all lowercase
- The selected output should be displayed on the page


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :sparkles: New feature       |

## Updates

### Before
![Screen Cast 2021-06-07 at 6 48 41 PM](https://user-images.githubusercontent.com/58532369/121096874-074c7980-c7c1-11eb-8872-dacb62063c90.gif)


### After

<!-- If UI feature, take provide screenshots -->
![Screen Cast 2021-06-07 at 6 47 10 PM](https://user-images.githubusercontent.com/58532369/121096786-dc622580-c7c0-11eb-80ec-79304afe47aa.gif)


## Testing Steps / QA Criteria

To test the feature, launch the app locally from your terminal:
- Pull down this branch with `git pull origin cf-feature-work` and check the branch out with `git checkout origin cf-feature-work`
- Run npm start to launch the app in your browser at http://localhost:3000

Within the app, you should be able to input text into the form, then click either the "Lowercase-ify" or "Uppercase-ify" button and see the expected output displayed on the page.